### PR TITLE
添加svn分支url获取脚本

### DIFF
--- a/svn-url.sh
+++ b/svn-url.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+url=$(svn info | grep "^URL" | awk '{print $2}') 
+if [ $url="svn: '.' is not a working copy" ]; then
+  exit
+fi
+echo $url
+if [ $(uname)="Darwin" ]; then
+  echo -n $url | pbcopy
+else
+  echo -n $url | xsel -b 
+fi


### PR DESCRIPTION
减少鼠标复制分支的url操作，个人经常在需要合并代码或者其他需要svn分支的时候使用
