### PR TITLE
add support for mac os

### DIFF
--- a/tcp-connection-state-counter.sh
+++ b/tcp-connection-state-counter.sh
@@ -6,8 +6,8 @@
 #   $ ./tcp-connection-state-counter.sh
 #
 # @author Jerry Lee
-
-netstat -tna | awk 'NR > 2 {
+# on mac osx , netstat need to using -p tcp to get only tcp output.
+netstat -tna `[ ! -z $(uname|grep Darwin) ] && echo "-ptcp"` | awk 'NR > 2 {
     s[$NF]++
 }
 


### PR DESCRIPTION
on mac osx , netstat need to using -p tcp to get only tcp output.
tested on
osx with bash && zsh
linux with bash && zsh