### PR TITLE
执行脚本的用户名超过8个字符时无法执行脚本

### DIFF
--- a/show-busy-java-threads
+++ b/show-busy-java-threads
@@ -237,7 +237,7 @@ for ((i = 0; update_count <= 0 || i < update_count; ++i)); do
     [ -n "$append_file" ] && headInfo >> "$append_file"
     [ "$update_count" -ne 1 ] && headInfo
 
-    ps -Leo pid,lwp,user,comm,pcpu --no-headers | {
+    ps -Leo pid,lwp -o ruser=${USER} -o comm,pcpu --no-headers | {
         [ -z "${pid}" ] &&
         awk '$4=="java"{print $0}' ||
         awk -v "pid=${pid}" '$1==pid,$4=="java"{print $0}'


### PR DESCRIPTION
ps -o user参数，当用户超过8个时，超过部分会显示为+号。例如：whoami=njiclscy-7

`ps -Leo pid,lwp,user,comm,pcpu --no-headers`
19317 19649 **njiclsc+** java             0.0

执行脚本提示：
```
[1] Fail to jstack Busy(0.2%) thread(19826/0x4d72) stack of java process(19317) under user(njiclsc+).
User of java process(njiclsc+) is not current user(njiclscy-7), need sudo to run again:
```
这个问题导致脚本无法执行。但实际上启动Java进程的用户确实是njiclscy-7

PR的修改方法是取出当前用户名，使用ruser选项输出用户名。